### PR TITLE
Scans source and transcription fixes

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -62,7 +62,6 @@
 		<dc:language>en-US</dc:language>
 		<dc:source>https://www.gutenberg.org/ebooks/3091</dc:source>
 		<dc:source>https://catalog.hathitrust.org/Record/100105290</dc:source>
-		<dc:source>https://catalog.hathitrust.org/Record/005974457</dc:source>
 		<meta property="se:word-count">95588</meta>
 		<meta property="se:reading-ease.flesch">67.99</meta>
 		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/Eight_Hundred_Leagues_on_the_Amazon</meta>

--- a/src/epub/text/chapter-2-12.xhtml
+++ b/src/epub/text/chapter-2-12.xhtml
@@ -259,8 +259,8 @@
 					<tr>
 						<td>Total</td>
 						<td>…</td>
-						<td>276</td>
-						<td>times.</td>
+						<td>64</td>
+						<td>vowels.</td>
 					</tr>
 				</tfoot>
 			</table>

--- a/src/epub/text/chapter-2-14.xhtml
+++ b/src/epub/text/chapter-2-14.xhtml
@@ -98,7 +98,7 @@
 				<tbody>
 					<tr>
 						<td>
-							<i>s.yf</i>
+							<i>o.yf</i>
 						</td>
 						<td>
 							<i>rdy.</i>


### PR DESCRIPTION
Transcription:
1. The transcription incorrectly has the same table footer for two tables in 2.12 ([scans](https://babel.hathitrust.org/cgi/pt?id=osu.32435018727610&seq=193))
2. Typo in 2.14 ([scans](https://babel.hathitrust.org/cgi/pt?id=osu.32435018727610&seq=232))

Scans:
- The first hathitrust catalog record has both volume 2 and volume 1